### PR TITLE
Rename `to_vec` to `into_vec`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic-array"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["debris <marek.kotewicz@gmail.com>"]
 license = "MIT"
 description = "Elastic vector backed by fixed size array"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ macro_rules! impl_elastic_array {
 			len: usize
 		}
 
-		impl<T> Eq for $name<T> where T: Eq { } 
+		impl<T> Eq for $name<T> where T: Eq { }
 
 		impl<T> fmt::Debug for $name<T> where T: fmt::Debug {
 			fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
@@ -158,7 +158,7 @@ macro_rules! impl_elastic_array {
 				self.insert_slice(len, elements)
 			}
 
-			pub fn to_vec(self) -> Vec<T> {
+			pub fn into_vec(self) -> Vec<T> {
 				match self.raw {
 					$dummy::Arr(a) => {
 						let mut vec = vec![];


### PR DESCRIPTION
`to_*` in Rust is usually reserved for functions that convert a reference of one type to an owned value of another type (for example, `<&[T]>::to_vec`, `ToOwned::to_owned`). Functions that convert an owned value of one type to an owned value of another type usually use `into_*`. This PR reflects that.