### PR TITLE
heapsize does not run no_std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ description = "Elastic vector backed by fixed size array"
 repository = "https://github.com/debris/elastic-array"
 
 [dependencies]
-heapsize = "0.4"
+heapsize = { version = "0.4", optional = true }
 
 [dev-dependencies]
 rand = "0.4"
@@ -18,4 +18,5 @@ travis-ci = { repository = "debris/elastic-array" }
 [features]
 default = ["std"]
 std = [
+  "heapsize"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic-array"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["debris <marek.kotewicz@gmail.com>"]
 license = "MIT"
 description = "Elastic vector backed by fixed size array"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(not(feature = "std"), feature(alloc))]
 
+#[cfg(feature = "std")]
 extern crate heapsize;
 
 #[cfg(not(feature = "std"))]
@@ -22,6 +23,7 @@ use core_::{
 #[cfg(not(feature = "std"))]
 use alloc::vec::Vec;
 
+#[cfg(feature = "std")]
 use heapsize::HeapSizeOf;
 
 #[macro_export]
@@ -92,6 +94,7 @@ macro_rules! impl_elastic_array {
 			}
 		}
 
+		#[cfg(feature = "std")]
 		impl<T> HeapSizeOf for $name<T> where T: HeapSizeOf {
 			fn heap_size_of_children(&self) -> usize {
 				match self.raw {


### PR DESCRIPTION
Thanks @debris for merging previous pr.
I did realize that heapsize is blocking no_std usage (my fault for not testing properly before).
This PR remove heapsize dependency when running no_std.