### PR TITLE
Enable no_std builds on stable rust.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "elastic-array"
-version = "0.10.2"
+version = "0.10.3"
 authors = ["debris <marek.kotewicz@gmail.com>"]
 license = "MIT"
 description = "Elastic vector backed by fixed size array"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(not(feature = "std"), feature(alloc))]
 
 #[cfg(feature = "std")]
 extern crate heapsize;


### PR DESCRIPTION
The alloc crate is now stable. The feature flag is no longer needed.

Changes:

- remove #[feature(alloc)] as it is no longer needed
- bump version in preparation for `cargo publish`